### PR TITLE
Feature/v0 11 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ app.get(
 ## Installation
 
 ```bash
-npm install tyex
+npm i tyex @sinclair/typebox ajv ajv-formats express
 ```
 
 ## Examples

--- a/examples/cats-api/index.ts
+++ b/examples/cats-api/index.ts
@@ -28,7 +28,7 @@ app.use(
 );
 
 app.use(express.json());
-t.use("/api/cats", catsRoutes);
+t.mount("/api/cats", catsRoutes);
 
 app.use(errorHandler);
 

--- a/examples/cats-api/routes/cats.ts
+++ b/examples/cats-api/routes/cats.ts
@@ -5,8 +5,8 @@ import { Cat, Error } from "./dtos";
 const router = tyex.Router();
 
 const cats: Static<typeof Cat>[] = [
-  { id: 1, name: "Whiskers", breed: "Persian", age: 5 },
-  { id: 2, name: "Luna", breed: "Siamese", age: 3 },
+  { id: 1, name: "Whiskers", breed: "Persian", age: 5, img: null },
+  { id: 2, name: "Luna", breed: "Siamese", age: 3, img: null },
 ];
 
 router.get(
@@ -18,9 +18,15 @@ router.get(
         in: "query",
         name: "limit",
         required: false,
-        schema: Options(Type.Integer({ minimum: 1, maximum: 100 }), {
-          default: 10,
-        }),
+        schema: Options(
+          Type.Integer({
+            minimum: 1,
+            maximum: 100,
+          }),
+          {
+            default: 10,
+          },
+        ),
       },
     ],
     responses: {
@@ -110,6 +116,7 @@ router.post(
       name: req.body.name,
       breed: req.body.breed,
       age: req.body.age,
+      img: null,
     };
 
     cats.push(newCat);

--- a/examples/cats-api/routes/cats.ts
+++ b/examples/cats-api/routes/cats.ts
@@ -1,5 +1,5 @@
 import { Type, type Static } from "@sinclair/typebox";
-import tyex, { Options } from "../../../src";
+import tyex, { TypeOpenAPI } from "../../../src";
 import { Cat, Error } from "./dtos";
 
 const router = tyex.Router();
@@ -18,7 +18,7 @@ router.get(
         in: "query",
         name: "limit",
         required: false,
-        schema: Options(
+        schema: TypeOpenAPI.Options(
           Type.Integer({
             minimum: 1,
             maximum: 100,

--- a/examples/cats-api/routes/dtos.ts
+++ b/examples/cats-api/routes/dtos.ts
@@ -1,12 +1,26 @@
 import { Type } from "@sinclair/typebox";
+import { Nullable } from "../../../src";
 
 export const Error = Type.Object({
   message: Type.String(),
 });
 
 export const Cat = Type.Object({
-  id: Type.Integer({ description: "The cat's unique identifier" }),
-  name: Type.String({ description: "The cat's name" }),
-  breed: Type.String({ description: "The cat's breed" }),
-  age: Type.Integer({ description: "The cat's age in years" }),
+  id: Type.Integer({
+    description: "The cat's unique identifier",
+  }),
+  name: Type.String({
+    description: "The cat's name",
+  }),
+  breed: Type.String({
+    description: "The cat's breed",
+  }),
+  age: Type.Integer({
+    description: "The cat's age in years",
+  }),
+  img: Nullable(
+    Type.String({
+      description: "The cat's image URL",
+    }),
+  ),
 });

--- a/examples/cats-api/routes/dtos.ts
+++ b/examples/cats-api/routes/dtos.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import { Nullable } from "../../../src";
+import { Nullable, StringEnum } from "../../../src";
 
 export const Error = Type.Object({
   message: Type.String(),
@@ -12,7 +12,7 @@ export const Cat = Type.Object({
   name: Type.String({
     description: "The cat's name",
   }),
-  breed: Type.String({
+  breed: StringEnum(["Siamese", "Persian", "MaineCoon", "Other"], {
     description: "The cat's breed",
   }),
   age: Type.Integer({

--- a/examples/cats-api/routes/dtos.ts
+++ b/examples/cats-api/routes/dtos.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import { Nullable, StringEnum } from "../../../src";
+import { TypeOpenAPI } from "../../../src";
 
 export const Error = Type.Object({
   message: Type.String(),
@@ -12,13 +12,13 @@ export const Cat = Type.Object({
   name: Type.String({
     description: "The cat's name",
   }),
-  breed: StringEnum(["Siamese", "Persian", "MaineCoon", "Other"], {
+  breed: TypeOpenAPI.StringEnum(["Siamese", "Persian", "MaineCoon", "Other"], {
     description: "The cat's breed",
   }),
   age: Type.Integer({
     description: "The cat's age in years",
   }),
-  img: Nullable(
+  img: TypeOpenAPI.Nullable(
     Type.String({
       description: "The cat's image URL",
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { Tyex } from "./tyex";
 
 export type { Tyex };
 export { TyexError, ValidationError } from "./errors";
-export { Options, Nullable } from "./typebox";
+export { Options, Nullable, StringEnum } from "./typebox";
 
 interface Options {
   ajv?: Ajv;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,12 @@ import addFormats from "ajv-formats";
 
 import { Router } from "./router";
 import { Tyex } from "./tyex";
+import { Options, Nullable, StringEnum } from "./typebox";
 
 export type { Tyex };
 export { TyexError, ValidationError } from "./errors";
-export { Options, Nullable, StringEnum } from "./typebox";
+
+export const TypeOpenAPI = { Options, Nullable, StringEnum };
 
 interface Options {
   ajv?: Ajv;

--- a/src/router.ts
+++ b/src/router.ts
@@ -24,7 +24,7 @@ export class Router {
 
   _setup(tyex: Tyex, prefix?: string) {
     this.#validator = new Validator(tyex.ajv);
-    tyex.routes._addChild(this.#routes, prefix);
+    tyex.routes.addChild(this.#routes, prefix);
     return this.#router;
   }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -20,7 +20,7 @@ export class Routes {
 
     for (const child of this.#children) {
       routes.push(
-        ...child.routes.#collection.map((route) => ({
+        ...child.routes.get().map((route) => ({
           method: route.method,
           path: child.prefix + route.path,
           definition: route.definition,
@@ -35,7 +35,7 @@ export class Routes {
     this.#collection.push({ method, path, definition: def });
   }
 
-  _addChild(child: Routes, prefix = "") {
+  addChild(child: Routes, prefix = "") {
     this.#children.push({ routes: child, prefix });
   }
 }

--- a/src/tyex.ts
+++ b/src/tyex.ts
@@ -55,9 +55,23 @@ export class Tyex {
     };
   }
 
+  /* v8 ignore start */
+  /**
+   * @deprecated For Tyex routers use mount(), for Express middleware use express.use()
+   * @example
+   * app.mount('/api', myTyexRouter)     // Tyex routers
+   * app.express.use(middleware)         // Express middleware
+   */
   use(path: string, router: Router): void;
+  /**
+   * @deprecated For Tyex routers use mount(), for Express middleware use express.use()
+   * @example
+   * app.mount('/api', myTyexRouter)     // Tyex routers
+   * app.express.use(middleware)         // Express middleware
+   */
   use(router: Router): void;
   use(...args: [string, Router] | [Router]) {
+    console.warn("Warning: use() is deprecated. Please use mount() instead.");
     if (args.length === 2) {
       const [path, router] = args;
       this.express.use(path, router._setup(this, path));
@@ -65,6 +79,20 @@ export class Tyex {
       const [router] = args;
       this.express.use(router._setup(this));
     }
+  }
+  /* v8 ignore stop */
+
+  mount(path: string, router: Router): void;
+  mount(router: Router): void;
+  mount(...args: [string, Router] | [Router]) {
+    if (args.length === 2) {
+      const [path, router] = args;
+      this.express.use(path, router._setup(this, path));
+    } else {
+      const [router] = args;
+      this.express.use(router._setup(this));
+    }
+    return this;
   }
 
   get<

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -6,7 +6,7 @@ import {
   Type,
 } from "@sinclair/typebox";
 
-export type TOptions<
+type TOptions<
   Type extends TSchema,
   Options extends Record<PropertyKey, unknown>,
 > = Type & Options;

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -1,4 +1,10 @@
-import { type Static, type TSchema, CloneType, Type } from "@sinclair/typebox";
+import {
+  type SchemaOptions,
+  type Static,
+  type TSchema,
+  CloneType,
+  Type,
+} from "@sinclair/typebox";
 
 export type TOptions<
   Type extends TSchema,
@@ -16,4 +22,14 @@ export const Nullable = <T extends TSchema>(schema: T) =>
   Type.Unsafe<Static<T> | null>({
     ...schema,
     nullable: true,
+  });
+
+export const StringEnum = <T extends string[]>(
+  values: [...T],
+  options?: SchemaOptions,
+) =>
+  Type.Unsafe<T[number]>({
+    type: "string",
+    enum: values,
+    ...options,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,8 @@ export type Handler<
       [MediaType in keyof ReqBodyContent]: ReqBodyContent[MediaType]["schema"] extends TSchema
         ? ReqBodyRequired extends true
           ? Static<ReqBodyContent[MediaType]["schema"]>
-          : Static<ReqBodyContent[MediaType]["schema"]> | Record<string, never>
+          : // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+            Static<ReqBodyContent[MediaType]["schema"]> | {}
         : never;
     }[keyof ReqBodyContent],
     {

--- a/tests/methods.test.ts
+++ b/tests/methods.test.ts
@@ -221,7 +221,7 @@ describe("Router methods", () => {
   test.each(methods)("Should handle %s requests", async (method) => {
     const t = tyex();
     const router = tyex.Router();
-    t.use(router);
+    t.mount(router);
 
     const json = { message: "success" };
 
@@ -253,7 +253,7 @@ describe("Router methods", () => {
   test("Should execute middlewares in order", async () => {
     const t = tyex();
     const router = tyex.Router();
-    t.use(router);
+    t.mount(router);
 
     const order: number[] = [];
 
@@ -285,7 +285,7 @@ describe("Router methods", () => {
   test("Should handle resolved promises on handlers", async () => {
     const t = tyex();
     const router = tyex.Router();
-    t.use(router);
+    t.mount(router);
 
     const json = { message: "success" };
 
@@ -319,7 +319,7 @@ describe("Router methods", () => {
     const t = tyex();
     const app = t.express;
     const router = tyex.Router();
-    t.use(router);
+    t.mount(router);
 
     const error = new Error("rejection");
 
@@ -362,7 +362,7 @@ describe("Router methods without definition", () => {
   test.each(methods)("Should handle %s requests", async (method) => {
     const t = tyex();
     const router = tyex.Router();
-    t.use(router);
+    t.mount(router);
 
     const json = { message: "success" };
 
@@ -379,7 +379,7 @@ describe("Router methods without definition", () => {
   test("Should execute middlewares in order", async () => {
     const t = tyex();
     const router = tyex.Router();
-    t.use(router);
+    t.mount(router);
 
     const order: number[] = [];
 
@@ -408,7 +408,7 @@ describe("Router methods without definition", () => {
   test("Should handle resolved promises on handlers", async () => {
     const t = tyex();
     const router = tyex.Router();
-    t.use(router);
+    t.mount(router);
 
     const json = { message: "success" };
 
@@ -427,7 +427,7 @@ describe("Router methods without definition", () => {
     const t = tyex();
     const app = t.express;
     const router = tyex.Router();
-    t.use(router);
+    t.mount(router);
 
     const error = new Error("rejection");
 

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -4,7 +4,7 @@ import SwaggerParser from "@apidevtools/swagger-parser";
 import express from "express";
 import request from "supertest";
 
-import tyex, { Nullable, Options, StringEnum } from "../src";
+import tyex, { TypeOpenAPI } from "../src";
 
 describe("OpenAPI Middleware", () => {
   test("Should serve OpenAPI specification with correct info", async () => {
@@ -211,8 +211,8 @@ describe("OpenAPI Middleware", () => {
     const PetSchema = Type.Object({
       id: Type.Number(),
       name: Type.String(),
-      type: StringEnum(["foo", "bar"]),
-      description: Nullable(Type.String()),
+      type: TypeOpenAPI.StringEnum(["foo", "bar"]),
+      description: TypeOpenAPI.Nullable(Type.String()),
     });
 
     router.get(
@@ -224,7 +224,7 @@ describe("OpenAPI Middleware", () => {
             name: "limit",
             in: "query",
             required: false,
-            schema: Options(Type.Integer(), {
+            schema: TypeOpenAPI.Options(Type.Integer(), {
               default: 10,
             }),
           },

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -106,7 +106,7 @@ describe("OpenAPI Middleware", () => {
       res.status(204).send();
     });
 
-    t.use("/api", router);
+    t.mount("/api", router);
 
     const response = await request(app)
       .get("/openapi")
@@ -298,7 +298,7 @@ describe("OpenAPI Middleware", () => {
       res.status(204).send();
     });
 
-    t.use("/api", router);
+    t.mount("/api", router);
 
     const response = await request(app).get("/openapi").expect(200);
 

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -4,7 +4,7 @@ import SwaggerParser from "@apidevtools/swagger-parser";
 import express from "express";
 import request from "supertest";
 
-import tyex, { Nullable, Options } from "../src";
+import tyex, { Nullable, Options, StringEnum } from "../src";
 
 describe("OpenAPI Middleware", () => {
   test("Should serve OpenAPI specification with correct info", async () => {
@@ -208,6 +208,13 @@ describe("OpenAPI Middleware", () => {
       }),
     );
 
+    const PetSchema = Type.Object({
+      id: Type.Number(),
+      name: Type.String(),
+      type: StringEnum(["foo", "bar"]),
+      description: Nullable(Type.String()),
+    });
+
     router.get(
       "/pets",
       {
@@ -233,14 +240,7 @@ describe("OpenAPI Middleware", () => {
             description: "List of pets",
             content: {
               "application/json": {
-                schema: Type.Array(
-                  Type.Object({
-                    id: Type.Number(),
-                    name: Type.String(),
-                    type: Type.String(),
-                    description: Nullable(Type.String()),
-                  }),
-                ),
+                schema: Type.Array(PetSchema),
               },
             },
           },
@@ -259,10 +259,7 @@ describe("OpenAPI Middleware", () => {
           required: true,
           content: {
             "application/json": {
-              schema: Type.Object({
-                name: Type.String(),
-                type: Type.String(),
-              }),
+              schema: Type.Omit(PetSchema, ["id"]),
             },
           },
         },
@@ -271,11 +268,7 @@ describe("OpenAPI Middleware", () => {
             description: "Pet created",
             content: {
               "application/json": {
-                schema: Type.Object({
-                  id: Type.Number(),
-                  name: Type.String(),
-                  type: Type.String(),
-                }),
+                schema: PetSchema,
               },
             },
           },

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -4,7 +4,7 @@ import SwaggerParser from "@apidevtools/swagger-parser";
 import express from "express";
 import request from "supertest";
 
-import tyex from "../src";
+import tyex, { Nullable, Options } from "../src";
 
 describe("OpenAPI Middleware", () => {
   test("Should serve OpenAPI specification with correct info", async () => {
@@ -217,7 +217,9 @@ describe("OpenAPI Middleware", () => {
             name: "limit",
             in: "query",
             required: false,
-            schema: Type.Number(),
+            schema: Options(Type.Integer(), {
+              default: 10,
+            }),
           },
           {
             name: "type",
@@ -236,6 +238,7 @@ describe("OpenAPI Middleware", () => {
                     id: Type.Number(),
                     name: Type.String(),
                     type: Type.String(),
+                    description: Nullable(Type.String()),
                   }),
                 ),
               },

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -21,7 +21,7 @@ describe("Routes", () => {
     const def = { responses: {} };
 
     child.add("get", "/users", def);
-    parent._addChild(child, "/api");
+    parent.addChild(child, "/api");
 
     expect(parent.get()).toStrictEqual([
       { method: "get", path: "/api/users", definition: def },
@@ -34,7 +34,7 @@ describe("Routes", () => {
     const def = { responses: {} };
 
     child.add("get", "/users", def);
-    parent._addChild(child);
+    parent.addChild(child);
 
     expect(parent.get()).toStrictEqual([
       { method: "get", path: "/users", definition: def },
@@ -46,7 +46,7 @@ describe("Routes", () => {
     const child = new Routes();
     const def = { responses: {} };
 
-    parent._addChild(child, "/api");
+    parent.addChild(child, "/api");
     child.add("get", "/users", def);
     child.add("post", "/products", def);
 
@@ -62,8 +62,8 @@ describe("Routes", () => {
     const secondChild = new Routes();
     const def = { responses: {} };
 
-    parent._addChild(firstChild, "/api/v1");
-    parent._addChild(secondChild, "/api/v2");
+    parent.addChild(firstChild, "/api/v1");
+    parent.addChild(secondChild, "/api/v2");
 
     firstChild.add("get", "/users", def);
     secondChild.add("get", "/users", def);
@@ -71,6 +71,39 @@ describe("Routes", () => {
     expect(parent.get()).toStrictEqual([
       { method: "get", path: "/api/v1/users", definition: def },
       { method: "get", path: "/api/v2/users", definition: def },
+    ]);
+  });
+
+  test("Should handle nested children (child of child) with single route", () => {
+    const parent = new Routes();
+    const child = new Routes();
+    const grandChild = new Routes();
+    const def = { responses: {} };
+
+    grandChild.add("get", "/profiles", def);
+    child.addChild(grandChild, "/v1");
+    parent.addChild(child, "/api");
+
+    expect(parent.get()).toStrictEqual([
+      { method: "get", path: "/api/v1/profiles", definition: def },
+    ]);
+  });
+
+  test("Should propagate new routes through multiple levels of nesting", () => {
+    const parent = new Routes();
+    const child = new Routes();
+    const grandChild = new Routes();
+    const def = { responses: {} };
+
+    grandChild.add("get", "/profiles", def);
+    child.addChild(grandChild, "/v1");
+    parent.addChild(child, "/api");
+
+    grandChild.add("post", "/settings", def);
+
+    expect(parent.get()).toStrictEqual([
+      { method: "get", path: "/api/v1/profiles", definition: def },
+      { method: "post", path: "/api/v1/settings", definition: def },
     ]);
   });
 });

--- a/tests/typebox.test.ts
+++ b/tests/typebox.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import request from "supertest";
 import { Type } from "@sinclair/typebox";
 
-import tyex, { Nullable, Options } from "../src";
+import tyex, { Nullable, Options, StringEnum } from "../src";
 import bodyParser from "body-parser";
 
 describe("Options helper", () => {
@@ -91,5 +91,95 @@ describe("Nullable helper", () => {
     const response = await request(t.express).post("/").send(body);
 
     expect(response.body).toStrictEqual(body);
+  });
+});
+
+describe("StringEnum helper", () => {
+  test("should accept valid values", async () => {
+    const t = tyex();
+    t.express.use(bodyParser.json());
+
+    t.post(
+      "/",
+      {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: Type.Object({
+                foo: StringEnum(["bar", "baz"]),
+              }),
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "",
+            content: {
+              "application/json": {
+                schema: Type.Object({
+                  foo: StringEnum(["bar", "baz"]),
+                }),
+              },
+            },
+          },
+        },
+      },
+      (req, res) => {
+        const foo: "bar" | "baz" = req.body.foo;
+        res.json({ foo });
+      },
+    );
+
+    const body = {
+      foo: "bar",
+    };
+    const response = await request(t.express).post("/").send(body);
+
+    expect(response.body).toStrictEqual(body);
+  });
+
+  test("should reject invalid values", async () => {
+    const t = tyex();
+    t.express.use(bodyParser.json());
+
+    t.post(
+      "/",
+      {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: Type.Object({
+                foo: StringEnum(["bar", "baz"]),
+              }),
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "",
+            content: {
+              "application/json": {
+                schema: Type.Object({
+                  foo: StringEnum(["bar", "baz"]),
+                }),
+              },
+            },
+          },
+        },
+      },
+      (req, res) => {
+        const foo: "bar" | "baz" = req.body.foo;
+        res.json({ foo });
+      },
+    );
+
+    const body = {
+      foo: "qux",
+    };
+    const response = await request(t.express).post("/").send(body);
+
+    expect(response.status).toBe(400);
   });
 });

--- a/tests/typebox.test.ts
+++ b/tests/typebox.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import request from "supertest";
 import { Type } from "@sinclair/typebox";
 
-import tyex, { Nullable, Options, StringEnum } from "../src";
+import tyex, { TypeOpenAPI } from "../src";
 import bodyParser from "body-parser";
 
 describe("Options helper", () => {
@@ -18,7 +18,7 @@ describe("Options helper", () => {
             in: "query",
             name: "int",
             required: false,
-            schema: Options(Type.Integer(), {
+            schema: TypeOpenAPI.Options(Type.Integer(), {
               default: defaultInt,
             }),
           },
@@ -61,7 +61,7 @@ describe("Nullable helper", () => {
           content: {
             "application/json": {
               schema: Type.Object({
-                foo: Nullable(Type.String()),
+                foo: TypeOpenAPI.Nullable(Type.String()),
               }),
             },
           },
@@ -72,7 +72,7 @@ describe("Nullable helper", () => {
             content: {
               "application/json": {
                 schema: Type.Object({
-                  foo: Nullable(Type.String()),
+                  foo: TypeOpenAPI.Nullable(Type.String()),
                 }),
               },
             },
@@ -107,7 +107,7 @@ describe("StringEnum helper", () => {
           content: {
             "application/json": {
               schema: Type.Object({
-                foo: StringEnum(["bar", "baz"]),
+                foo: TypeOpenAPI.StringEnum(["bar", "baz"]),
               }),
             },
           },
@@ -118,7 +118,7 @@ describe("StringEnum helper", () => {
             content: {
               "application/json": {
                 schema: Type.Object({
-                  foo: StringEnum(["bar", "baz"]),
+                  foo: TypeOpenAPI.StringEnum(["bar", "baz"]),
                 }),
               },
             },
@@ -151,7 +151,7 @@ describe("StringEnum helper", () => {
           content: {
             "application/json": {
               schema: Type.Object({
-                foo: StringEnum(["bar", "baz"]),
+                foo: TypeOpenAPI.StringEnum(["bar", "baz"]),
               }),
             },
           },
@@ -162,7 +162,7 @@ describe("StringEnum helper", () => {
             content: {
               "application/json": {
                 schema: Type.Object({
-                  foo: StringEnum(["bar", "baz"]),
+                  foo: TypeOpenAPI.StringEnum(["bar", "baz"]),
                 }),
               },
             },

--- a/tests/typebox.test.ts
+++ b/tests/typebox.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import request from "supertest";
+import { Type } from "@sinclair/typebox";
+
+import tyex, { Nullable, Options } from "../src";
+import bodyParser from "body-parser";
+
+describe("Options helper", () => {
+  test("should use default value when undefined", async () => {
+    const t = tyex();
+
+    const defaultInt = 1000;
+    t.get(
+      "/",
+      {
+        parameters: [
+          {
+            in: "query",
+            name: "int",
+            required: false,
+            schema: Options(Type.Integer(), {
+              default: defaultInt,
+            }),
+          },
+        ],
+        responses: {
+          200: {
+            description: "",
+            content: {
+              "application/json": {
+                schema: Type.Object({
+                  int: Type.Integer(),
+                }),
+              },
+            },
+          },
+        },
+      },
+      (req, res) => {
+        const int: number = req.query.int;
+        res.json({ int });
+      },
+    );
+
+    const response = await request(t.express).get("/");
+
+    expect(response.body).toStrictEqual({ int: defaultInt });
+  });
+});
+
+describe("Nullable helper", () => {
+  test("should allow null values", async () => {
+    const t = tyex();
+    t.express.use(bodyParser.json());
+
+    t.post(
+      "/",
+      {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: Type.Object({
+                foo: Nullable(Type.String()),
+              }),
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "",
+            content: {
+              "application/json": {
+                schema: Type.Object({
+                  foo: Nullable(Type.String()),
+                }),
+              },
+            },
+          },
+        },
+      },
+      (req, res) => {
+        const foo: string | null = req.body.foo;
+        res.json({ foo });
+      },
+    );
+
+    const body = {
+      foo: null,
+    };
+    const response = await request(t.express).post("/").send(body);
+
+    expect(response.body).toStrictEqual(body);
+  });
+});

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -4,7 +4,7 @@ import supertest from "supertest";
 import { Type } from "@sinclair/typebox";
 import { errorHandler } from "./utils/error.handler";
 
-import tyex, { Options } from "../src";
+import tyex from "../src";
 
 describe("Request Validation", () => {
   describe("Path Parameters", () => {
@@ -158,7 +158,7 @@ describe("Request Validation", () => {
       expect(response.body).toStrictEqual(path);
     });
 
-    test("Should reject when one of multiple parameters is invalid (too short)", async () => {
+    test("Should reject when one of multiple parameters is invalid", async () => {
       const t = tyex();
 
       t.get(
@@ -259,14 +259,6 @@ describe("Request Validation", () => {
               required: false,
               schema: Type.Boolean(),
             },
-            {
-              in: "query",
-              name: "sort",
-              required: false,
-              schema: Options(Type.String(), {
-                default: "asc",
-              }),
-            },
           ],
           responses: {
             200: {
@@ -278,7 +270,6 @@ describe("Request Validation", () => {
                     limit: Type.Optional(Type.Number()),
                     tags: Type.Optional(Type.Array(Type.String())),
                     published: Type.Optional(Type.Boolean()),
-                    sort: Type.String(),
                   }),
                 },
               },
@@ -301,10 +292,7 @@ describe("Request Validation", () => {
       const response = await supertest(t.express).get("/search").query(query);
 
       expect(response.status).toBe(200);
-      expect(response.body).toStrictEqual({
-        ...query,
-        sort: "asc",
-      });
+      expect(response.body).toStrictEqual(query);
     });
 
     test("Should validate request with only required parameters", async () => {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -689,8 +689,14 @@ describe("Request Validation", () => {
           },
         },
         (req, res) => {
-          // @ts-expect-error body is optional
-          res.status(201).json(req.body);
+          res.status(201).json({
+            // @ts-expect-error req.body is optional
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            email: req.body.email,
+            // @ts-expect-error req.body is optional
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            name: req.body.name,
+          });
         },
       );
       t.express.use(errorHandler);


### PR DESCRIPTION
## ⚠ BREAKING CHANGES
- **Reorganized TypeBox utilities** under the `TypeOpenAPI` namespace for better organization
- **Improved type safety** by replacing `Record<string, never>` with `{}` for optional request bodies (thanks to @mariogl)

## Features
- Added `StringEnum` helper for better OpenAPI enum type definitions
- Enhanced nested routing support
- Exposed `addChild` method
- Deprecated `use()` in favor of more explicit `mount()` method