### PR TITLE
Feature/v0 13 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,11 @@ tyex.handler(
 )
 ```
 
-### Generate OpenAPI Documentation
+### Generating OpenAPI Documentation
 
-The `tyex.openapi()` middleware automatically generates an OpenAPI document from your handlers:
+#### Option 1: Using the Middleware
+
+The `tyex.openapi()` middleware provides a quick way to expose your documentation on a route. It generates the spec on the first request.
 
 ```typescript
 // Basic usage
@@ -143,6 +145,24 @@ app.get(
     },
   }),
 );
+```
+
+#### Option 2: Programmatic Generation
+
+For more flexibility, you can generate the OpenAPI document directly as a JavaScript object using `oasGenerator`. This allows you to use the spec in build scripts, tests, or apply complex logic before serving it.
+
+```typescript
+// scripts/build-spec.js
+import app from "../src/app";
+import tyex from "tyex";
+import fs from "fs";
+
+// Generate the document object
+const oasDoc = tyex.oasGenerator(app);
+
+// Write it to a file
+fs.writeFileSync("./public/openapi.json", JSON.stringify(oasDoc));
+console.log("✅ OpenAPI spec generated successfully.");
 ```
 
 ### OpenAPI-Specific Types

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,14 @@
 import { handler } from "./handler";
+import { oasGenerator } from "./oas-generator";
 import { openapiMiddleware } from "./openapi-middleware";
 
 export { TypeOpenAPI } from "./oas-type";
 export { ValidationError } from "./req-validation";
 
-const tyex = { handler, openapi: openapiMiddleware };
+const tyex = {
+  handler,
+  openapi: openapiMiddleware,
+  oasGenerator,
+};
 
 export default tyex;

--- a/src/openapi-middleware.ts
+++ b/src/openapi-middleware.ts
@@ -3,11 +3,16 @@ import type { OpenAPIV3 } from "openapi-types";
 import { oasGenerator } from "./oas-generator";
 
 export interface Options {
-  document?: Omit<OpenAPIV3.Document, "paths">;
+  document?: OpenAPIV3.Document | Omit<OpenAPIV3.Document, "paths">;
 }
 
 export const openapiMiddleware = (options?: Options): RequestHandler => {
+  let cache: OpenAPIV3.Document | undefined;
   return (req, res) => {
-    res.json(oasGenerator(req.app, options?.document));
+    if (!cache) {
+      cache = oasGenerator(req.app, options?.document);
+    }
+
+    res.json(cache);
   };
 };

--- a/src/openapi-middleware.ts
+++ b/src/openapi-middleware.ts
@@ -7,18 +7,7 @@ export interface Options {
 }
 
 export const openapiMiddleware = (options?: Options): RequestHandler => {
-  let base = options?.document;
-  if (!base) {
-    base = {
-      openapi: "3.0.0",
-      info: {
-        title: "ExpressJS",
-        version: "0.0.0",
-      },
-    };
-  }
-  const oas = { ...base, paths: {} };
   return (req, res) => {
-    res.json(oasGenerator(req.app, oas));
+    res.json(oasGenerator(req.app, options?.document));
   };
 };

--- a/tests/oas-generator.test.ts
+++ b/tests/oas-generator.test.ts
@@ -222,4 +222,57 @@ describe("oas generator", () => {
 
     expect(oas.paths).toStrictEqual({});
   });
+
+  test("should create a default OAS document when baseOAS is undefined", () => {
+    const app = express();
+
+    const oas = oasGenerator(app);
+
+    expect(oas).toEqual({
+      openapi: "3.0.0",
+      info: {
+        title: "ExpressJS",
+        version: "0.0.0",
+      },
+      paths: {},
+    });
+  });
+
+  test("should add an empty paths object if baseOAS is provided without one", () => {
+    const app = express();
+
+    const baseOAS = {
+      openapi: "3.0.1",
+      info: {
+        title: "API Without Paths",
+        version: "1.2.3",
+      },
+    };
+
+    const oas = oasGenerator(app, baseOAS);
+
+    expect(oas).toEqual({
+      ...baseOAS,
+      paths: {},
+    });
+  });
+
+  test("should use paths object if baseOAS is provided with one", () => {
+    const app = express();
+
+    const baseOAS = {
+      openapi: "3.0.1",
+      info: {
+        title: "My Custom API",
+        version: "1.0.0",
+      },
+      paths: {
+        "/existing-path": {},
+      },
+    };
+
+    const oas = oasGenerator(app, baseOAS);
+
+    expect(oas).toStrictEqual(baseOAS);
+  });
 });

--- a/tests/openapi-middleware.test.ts
+++ b/tests/openapi-middleware.test.ts
@@ -45,26 +45,4 @@ describe("openapi middleware", () => {
       },
     });
   });
-
-  test("should incorporate base document", async () => {
-    const app = express();
-    const document = {
-      openapi: "3.0.0",
-      info: {
-        title: "Test API",
-        version: "1.0.0",
-        description: "API for testing",
-      },
-    };
-
-    app.use("/openapi.json", tyex.openapi({ document }));
-
-    const response = await request(app).get("/openapi.json");
-
-    expect(response.status).toBe(200);
-    expect(response.body).toStrictEqual({
-      ...document,
-      paths: {},
-    });
-  });
 });


### PR DESCRIPTION
- `oasGenerator` is now exported.
- The `openapi` middleware now caches the generated spec after the first request.