### PR TITLE
feat: update ValidationError to extend Error

### DIFF
--- a/src/req-validation.ts
+++ b/src/req-validation.ts
@@ -34,13 +34,13 @@ const ajv = addFormats(
   ],
 );
 
-export class ValidationError {
+export class ValidationError extends Error {
   status = 400;
   code = "VALIDATION_ERROR";
-  message = "Validation error";
   errors: ErrorObject[];
 
-  constructor(errors: ErrorObject[]) {
+  constructor(errors: ErrorObject[], options?: ErrorOptions) {
+    super("Validation error", options);
     this.errors = errors;
   }
 }


### PR DESCRIPTION
It's good practice for errors to extend the base `Error` class. This should be useful for `tyex` as it will make it easier for error-handlers to normalize the output.